### PR TITLE
Add to export `analysis/tools tracing` 

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,20 +6,7 @@ package(default_visibility = ["//visibility:public"])
 # `#include <slog_cc/context/context.h>`
 cc_library(
     name = "slog_cc",
-    hdrs = [
-        # TODO(vsbus): find a right way to add all hdrs here automatically
-        "//slog_cc/buffer:buffer.h",
-        "//slog_cc/buffer:buffer_data.h",
-        "//slog_cc/context:context.h",
-        "//slog_cc/events:event.h",
-        "//slog_cc/events:scope.h",
-        "//slog_cc/primitives:call_site.h",
-        "//slog_cc/primitives:record.h",
-        "//slog_cc/primitives:tag.h",
-        "//slog_cc/primitives:timestamps.h",
-        "//slog_cc/printer:printer.h",
-        "//slog_cc:slog.h",
-    ],
+    hdrs = glob(["src/*.h"]),
     copts = [
         # max optimizations
         "-O3",
@@ -44,6 +31,25 @@ cc_library(
     deps = [
         "//slog_cc",
         "//slog_cc/buffer:buffer_cc",
+    ],
+)
+
+cc_library(
+    name = "analysis_tools",
+    hdrs = [
+        "//analysis_tools/tracing:slog_trace_subscriber.h",
+    ],
+    copts = [
+        # max optimizations
+        "-O3",
+    ],
+
+    include_prefix = "analysis_tools",
+    includes = ["analysis_tools"],
+    strip_include_prefix = "analysis_tools",
+    deps = [
+        "//analysis_tools",
+        "@slog//:slog_cc",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,7 +6,7 @@ package(default_visibility = ["//visibility:public"])
 # `#include <slog_cc/context/context.h>`
 cc_library(
     name = "slog_cc",
-    hdrs = glob(["src/*.h"]),
+    hdrs = glob(["*.h"]),
     copts = [
         # max optimizations
         "-O3",

--- a/analysis_tools/tracing/BUILD
+++ b/analysis_tools/tracing/BUILD
@@ -9,6 +9,6 @@ cc_binary(
     linkopts = ["-lpthread"],
     deps = [
         ":slog_trace_subscriber",
-        "//:slog_cc",
+        ":slog_cc",
     ],
 )

--- a/test_import/example_project_cc_via_bazel/src/BUILD
+++ b/test_import/example_project_cc_via_bazel/src/BUILD
@@ -4,5 +4,6 @@ cc_test(
     deps = [
         "@com_github_google_googletest//:gtest_main",
         "@slog//:slog_cc",
+        "@analysis_tools/tracing::slog_trace_subsriber.h"
     ],
 )

--- a/test_import/example_project_cc_via_bazel/src/BUILD
+++ b/test_import/example_project_cc_via_bazel/src/BUILD
@@ -4,6 +4,6 @@ cc_test(
     deps = [
         "@com_github_google_googletest//:gtest_main",
         "@slog//:slog_cc",
-        "@analysis_tools/tracing::slog_trace_subsriber.h"
+        "@slog//:analysis_tools",
     ],
 )

--- a/test_import/example_project_cc_via_bazel/src/slog_test.cc
+++ b/test_import/example_project_cc_via_bazel/src/slog_test.cc
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 #include <slog_cc/buffer/buffer.h>
 #include <slog_cc/slog.h>
-#include <analysis_tools/tracing:slog_trace_subsriber.h>
+#include <analysis_tools/tracing/slog_trace_subsriber.h>
 
 
 TEST(SlogTest, basic) {

--- a/test_import/example_project_cc_via_bazel/src/slog_test.cc
+++ b/test_import/example_project_cc_via_bazel/src/slog_test.cc
@@ -15,6 +15,8 @@
 #include <gtest/gtest.h>
 #include <slog_cc/buffer/buffer.h>
 #include <slog_cc/slog.h>
+#include <analysis_tools/tracing:slog_trace_subsriber.h>
+
 
 TEST(SlogTest, basic) {
   SLOG(INFO) << "foo";


### PR DESCRIPTION
Before: 
`analysis-tools/tracing` not listed in BUILD.bazel file and not exporting. 

After: 
- `analysis_tools` added to BUILD.bazel file. Test fails. What could be the fix?
- auto add for *.h files added to BUILD.bazel file(not tested)