### PR TITLE
fix slog_py import via bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,1 @@
 build --cxxopt='-std=c++14'
-
-# TODO(vsbus): remove this flag, update repo to work with Bzlmod but also add import examples with
-# WORKSPACE that installs old (v7) bazel and anoter with Bzlmod and new (v9) bazel.
-build --incompatible_enable_workspace_file
-

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,6 @@
 build --cxxopt='-std=c++14'
+
+# TODO(vsbus): remove this flag, update repo to work with Bzlmod but also add import examples with
+# WORKSPACE that installs old (v7) bazel and anoter with Bzlmod and new (v9) bazel.
+build --incompatible_enable_workspace_file
+

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,7 +37,7 @@ cc_library(
     #   * add `include_prefix` to put all C++ slog include files behind slog_cc
     #     prefix dir.
     # Note: it sounds like using `strip_include_prefix` and `include_prefix`
-    # with same value doesn't make sense, but if we remove there params user
+    # with same value doesn't make sense, but if we remove these params user
     # project will not be able to see slog .h files for some reason.
     include_prefix = "slog_cc",
     includes = ["slog_cc"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -56,4 +56,5 @@ cc_library(
 py_library(
     name = "slog_py",
     deps = ["//slog_py"],
+    imports = ["slog"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -56,5 +56,8 @@ cc_library(
 py_library(
     name = "slog_py",
     deps = ["//slog_py"],
-    imports = ["slog"],
+    # We want slog to be imported as `from slog_py import slog` but slog_py is
+    # inside `slog` subdirectory so slog_py won't be visible by default. We add
+    # `slog` prefix into PYTHONPATH by adding `.` to the imports.
+    imports = ["."],
 )

--- a/slog_py/slog_pybind.cc
+++ b/slog_py/slog_pybind.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // NOLINT(namespace-avsoftware)
+#include <cstdint>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/test_import/example_project_cc_via_bazel/.bazelversion
+++ b/test_import/example_project_cc_via_bazel/.bazelversion
@@ -1,6 +1,6 @@
-# TODO(vsbus): update this test as improt via bazel5. Add a newer test with Bzlmod in bazel8.
 5.4.0
 # NOTE: next version 6.0.0 was causing build failure due to using googletest
 # 1.10, it was transitively using bazel_tools platform in the old way and
 # starting from 6.0.0 it isn't supported. To upgrade bazel we would need to
 # upgrade dependencies.
+# TODO(vsbus): update this test as improt via bazel5. Add a newer test with Bzlmod in bazel8.

--- a/test_import/example_project_cc_via_bazel/.bazelversion
+++ b/test_import/example_project_cc_via_bazel/.bazelversion
@@ -1,3 +1,4 @@
+# TODO(vsbus): update this test as improt via bazel5. Add a newer test with Bzlmod in bazel8.
 5.4.0
 # NOTE: next version 6.0.0 was causing build failure due to using googletest
 # 1.10, it was transitively using bazel_tools platform in the old way and

--- a/test_import/example_project_py_via_bazel/.bazelversion
+++ b/test_import/example_project_py_via_bazel/.bazelversion
@@ -1,0 +1,6 @@
+5.4.0
+# NOTE: next version 6.0.0 was causing build failure due to using googletest
+# 1.10, it was transitively using bazel_tools platform in the old way and
+# starting from 6.0.0 it isn't supported. To upgrade bazel we would need to
+# upgrade dependencies.
+# TODO(vsbus): update this test as improt via bazel5. Add a newer test with Bzlmod in bazel8.


### PR DESCRIPTION
* Fix CI to work with old Bazel feature with WORKSPACE files.
* Add `imports` to slog_py to make imports work correctly for user's side.
